### PR TITLE
Fixed advisory lcok getter. No need in Scan, because OID 2278 reterns…

### DIFF
--- a/database.go
+++ b/database.go
@@ -375,10 +375,8 @@ func (p *Pgpool) createTemplateDB() (string, error) {
 			// If we need to create a database, take an advisory lock on
 			// master database to prevent parallel creation of databases
 			// from several test processes.
-			var x interface{}
-			err = conn.
-				QueryRow(ctx, `SELECT pg_advisory_lock($1)`, lockID).
-				Scan(&x)
+			_, err = conn.
+				QueryRow(ctx, `SELECT pg_advisory_lock($1)`, lockID)
 			if err != nil {
 				return errors.WithStack(err)
 			}


### PR DESCRIPTION
… here(Void). It causes error

I encountered a scan error in &x when using the tool because OID 2278 is unfamiliar to the scanner. I found out that scanning is applicable only when receiving the result of the pg_try_advisory_lock function, which returns the status as a boolean value. In this case, a void is returned that cannot be scanned and this causes an error.